### PR TITLE
NEW - Add sorting for selected rows or cells

### DIFF
--- a/js/dataTables.select.js
+++ b/js/dataTables.select.js
@@ -110,6 +110,19 @@ DataTable.select.init = function ( dt ) {
 	dt.select.info( info );
 	ctx._select.className = className;
 
+
+	// Sort table based on selected rows. Requires Select Datatables extension
+	$.fn.dataTable.ext.order['select-checkbox'] = function ( settings, col ) {
+		return this.api().column( col, {order: 'index'} ).nodes().map( function ( td ) {
+			if ( settings._select.items === 'row' ) {
+				return $( td ).parent().hasClass( settings._select.className );
+			} else if ( settings._select.items === 'cell' ) {
+				return $( td ).hasClass( settings._select.className );
+			}
+			return false;
+		});
+	};
+
 	// If the init options haven't enabled select, but there is a selectable
 	// class name, then enable
 	if ( $( dt.table().node() ).hasClass( 'selectable' ) ) {


### PR DESCRIPTION
Link to example: https://jsfiddle.net/jpobley/8z4f71cg/embedded/result

I have found it useful to pin the selected rows to the "top" of the table  when I have rows selected across many pages. I wasn't sure if I should make a separate file for the plugin or just add it into `init()` function of the Select extension.

Finally, I haven't figure out ordering when `column` is the value of `select.items()`. Maybe it's not necessary, though, given how sorting is already performed.

Thoughts, suggestions, ideas, etc. are totally welcome!
