### PR TITLE
ISSUE #20 Clone output info instead of Append only

### DIFF
--- a/js/dataTables.select.js
+++ b/js/dataTables.select.js
@@ -472,7 +472,7 @@ function info ( api )
 		}
 
 		if ( output.text() !== '' ) {
-			el.append( output );
+			el.append( output.clone() );
 		}
 	} );
 }


### PR DESCRIPTION
ISSUE #20 In order to get multiple instance of info zone with select
output, we should clone the output element then append to info zone.
.append() moves elements in the DOM, so only the last info zone gonna get the output.