### PR TITLE
Change the namespace of body click handlers

### DIFF
--- a/js/dataTables.select.js
+++ b/js/dataTables.select.js
@@ -304,13 +304,14 @@ function disableMouseSelection( dt )
 {
 	var ctx = dt.settings()[0];
 	var selector = ctx._select.selector;
+	var container = dt.table().container();
 
-	$( dt.table().container() )
+	$( container )
 		.off( 'mousedown.dtSelect', selector )
 		.off( 'mouseup.dtSelect', selector )
 		.off( 'click.dtSelect', selector );
 
-	$('body').off( 'click.dtSelect' );
+	$('body').off( 'click.dtSelect' + container.id );
 }
 
 /**
@@ -392,7 +393,7 @@ function enableMouseSelection ( dt )
 		} );
 
 	// Blurable
-	$('body').on( 'click.dtSelect', function ( e ) {
+	$('body').on( 'click.dtSelect' + container.id, function ( e ) {
 		if ( ctx._select.blurable ) {
 			// If the click was inside the DataTables container, don't blur
 			if ( $(e.target).parents().filter( dt.table().container() ).length ) {


### PR DESCRIPTION
This commit changes the scope of body click handlers to individual table containers.

Previously, the scope of the handler was too wide and Blurable did not work properly on pages that contain multiple tables.

PR offered under MIT.