### PR TITLE
Amend #28

### DIFF
--- a/js/dataTables.select.js
+++ b/js/dataTables.select.js
@@ -304,14 +304,13 @@ function disableMouseSelection( dt )
 {
 	var ctx = dt.settings()[0];
 	var selector = ctx._select.selector;
-	var container = dt.table().container();
 
-	$( container )
+	$( dt.table().container() )
 		.off( 'mousedown.dtSelect', selector )
 		.off( 'mouseup.dtSelect', selector )
 		.off( 'click.dtSelect', selector );
 
-	$('body').off( 'click.dtSelect' + container.id );
+	$('body').off( 'click.dtSelect' + dt.table().node().id );
 }
 
 /**
@@ -393,7 +392,7 @@ function enableMouseSelection ( dt )
 		} );
 
 	// Blurable
-	$('body').on( 'click.dtSelect' + dt.table().container().id, function ( e ) {
+	$('body').on( 'click.dtSelect' + dt.table().node().id, function ( e ) {
 		if ( ctx._select.blurable ) {
 			// If the click was inside the DataTables container, don't blur
 			if ( $(e.target).parents().filter( dt.table().container() ).length ) {

--- a/js/dataTables.select.js
+++ b/js/dataTables.select.js
@@ -393,7 +393,7 @@ function enableMouseSelection ( dt )
 		} );
 
 	// Blurable
-	$('body').on( 'click.dtSelect' + container.id, function ( e ) {
+	$('body').on( 'click.dtSelect' + dt.table().container().id, function ( e ) {
 		if ( ctx._select.blurable ) {
 			// If the click was inside the DataTables container, don't blur
 			if ( $(e.target).parents().filter( dt.table().container() ).length ) {


### PR DESCRIPTION
This commit fixes a mistake that I made in #28. The mistake prevents click handlers from being removed in `disableMouseSelection`.

See comment: https://github.com/DataTables/Select/commit/97a59f56bb9ae39a304297533ff777940c5a91cc#diff-7d61f891a3f3cc950e50716b8600aa54R396