### PR TITLE
Fixed the incorrect "margin-top" property under compact mode.

### DIFF
--- a/css/select.dataTables.scss
+++ b/css/select.dataTables.scss
@@ -123,6 +123,24 @@ table.dataTable {
 			}
 		}
 	}
+
+	&.compact {
+		tbody td.select-checkbox,
+		tbody th.select-checkbox {
+			&:before {
+				margin-top: -12px;
+			}
+		}
+
+		tr.selected {
+			td.select-checkbox,
+			th.select-checkbox {
+				&:after {
+					margin-top: -16px;
+				}
+			}
+		}
+	}
 }
 
 div.dataTables_wrapper {


### PR DESCRIPTION
The rendering of this plugin seems to be incorrect under compact mode. This patch fixed the problem.

To reproduce the problem, simply use the [sample code](https://datatables.net/extensions/select/examples/initialisation/checkbox.html) and add "compact" class to the &lt;table&gt; element:

```
<table id="example" class="display compact" width="100%">
   ...  Table content ...
</table>
```
