### PR TITLE
Selector `tbody th` incorrect

### DIFF
--- a/css/select.dataTables.scss
+++ b/css/select.dataTables.scss
@@ -85,7 +85,7 @@ table.dataTable {
 	}
 
 	tbody td.select-checkbox,
-	tbody th.select-checkbox {
+	thead th.select-checkbox {
 		position: relative;
 
 		&:before,
@@ -129,7 +129,7 @@ table.dataTable {
 
 	&.compact {
 		tbody td.select-checkbox,
-		tbody th.select-checkbox {
+		thead th.select-checkbox {
 			&:before {
 				margin-top: -12px;
 			}


### PR DESCRIPTION
The selector `tbody th` will match nothing since `th` is inside `thead`. This commit corrects this little bug.