### PR TITLE
Check mark from heavy check mark to regular check mark

### DIFF
--- a/css/select.dataTables.scss
+++ b/css/select.dataTables.scss
@@ -112,7 +112,7 @@ table.dataTable {
 		td.select-checkbox,
 		th.select-checkbox {
 			&:after {
-				content: '\2714';
+				content: '\2713';
 
 				margin-top: -11px;
 				margin-left: -4px;


### PR DESCRIPTION
**Description of problem**: 
When using the Select extension the select checkbox default font does not render the check mark properly. It is outside the box that is supposed to contain it. This is because by default all browsers on Windows render the box with Segoe UI Emoji and not Segoe UI Symbol as show in the [example](https://datatables.net/extensions/select/examples/initialisation/checkbox.html "example").

One fix would be to change the font family for the select boxes, but personally I think an easier change is to modify line 115 in select.dataTables.scss from
`content: '\2714';`
to
`content: '\2713';`

[2713](https://www.htmlsymbols.xyz/unicode/U+2713 "2713") is the regular check mark instead of the heavy check mark, and renders the same across all browsers and operating systems without needing to modify font families. 

Example: http://live.datatables.net/sasopola/1/