### PR TITLE
add ApiSelectorModifier interface

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -25,6 +25,10 @@ declare module 'datatables.net' {
 		select: ApiSelect<Api<T>>
 	}
 
+	interface ApiSelectorModifier {
+		selected?: boolean | undefined;
+	}
+
 	interface ApiRowMethods<T> {
 		/**
 		 * Select a row


### PR DESCRIPTION
fixed typesciprt issue, when you cant use `table.rows({ selected: true})` , because missing ApiSelectorModifier interface definition with selected option

options documentation: [link](https://datatables.net/reference/type/selector-modifier#Options)