### PR TITLE
fix to get the checkbox to be checked if items is cell

### DIFF
--- a/js/dataTables.select.js
+++ b/js/dataTables.select.js
@@ -1900,6 +1900,7 @@ DataTable.render.select = function (valueProp, nameProp) {
 		var selected = dtRow._select_selected;
 		var ariaLabel = meta.settings.oLanguage.select.aria.rowCheckbox;
 		var selectable = meta.settings._select.selectable;
+		var closestElement = meta.settings._select.items === 'cell' ? 'td' : 'tr';
 
 		if (type === 'display') {
 			// Check if the row is selectable before showing the checkbox
@@ -1927,7 +1928,7 @@ DataTable.render.select = function (valueProp, nameProp) {
 					// And make sure this checkbox matches it's row as it is possible
 					// to check out of sync if this was clicked on to deselect a range
 					// but remains selected itself
-					this.checked = $(this).closest('tr').hasClass('selected');
+					this.checked = $(this).closest(closestElement).hasClass('selected');
 				})[0];
 		}
 		else if (type === 'type') {

--- a/test/options/select-checkbox-items.js
+++ b/test/options/select-checkbox-items.js
@@ -1,0 +1,117 @@
+describe('Select - type - select-checkbox items is row', function() {
+	let table;
+
+	dt.libs({
+		js: ['jquery', 'datatables', 'select'],
+		css: ['datatables', 'select']
+	});
+
+	describe('Functional tests', function() {
+		dt.html('basic');
+
+		it('No info', function() {
+			var cols = dt.getTestColumns();
+			cols[0].data = null;
+			cols[0].defaultContent = '';
+			cols[0].render = DataTable.render.select();
+
+			table = $('#example').DataTable({
+				select: {
+					items: 'row',
+					style: 'multi',
+					selector: 'td:first-child',
+				},
+				columns: cols,
+				order: [1, 'desc'],
+				columnDefs: [
+					{
+						orderable: true,
+						className: 'select-checkbox',
+						targets: -1,
+						orderDataType: 'select-checkbox'
+					}
+				]
+			});
+		});
+
+		it('Checkbox is unchecked before selection', function() {
+			expect($('tbody tr:eq(7) td:eq(0) input').prop('checked')).toBe(false);
+		});
+
+		it('Checkbox is checked when row is selected', function() {
+			$('tbody tr:eq(7) td:eq(0)').click();
+			expect($('tbody tr:eq(7)').hasClass('selected')).toBe(true);
+			expect($('tbody tr:eq(7) td:eq(0) input').prop('checked')).toBe(true);
+		});
+
+		it('Other rows remain unchecked', function() {
+			expect($('tbody tr:eq(0) td:eq(0) input').prop('checked')).toBe(false);
+			expect($('tbody tr:eq(1) td:eq(0) input').prop('checked')).toBe(false);
+		});
+
+		it('Checkbox is unchecked when row is deselected', function() {
+			$('tbody tr:eq(7) td:eq(0)').click();
+			expect($('tbody tr:eq(7)').hasClass('selected')).toBe(false);
+			expect($('tbody tr:eq(7) td:eq(0) input').prop('checked')).toBe(false);
+		});
+	});
+});
+
+describe('Select - type - select-checkbox items is cell ', function() {
+	let table;
+
+	dt.libs({
+		js: ['jquery', 'datatables', 'select'],
+		css: ['datatables', 'select']
+	});
+
+	describe('Functional tests', function() {
+		dt.html('basic');
+
+		it('No info', function() {
+			var cols = dt.getTestColumns();
+			cols[0].data = null;
+			cols[0].defaultContent = '';
+			cols[0].render = DataTable.render.select();
+
+			table = $('#example').DataTable({
+				select: {
+					items: 'cell',
+					style: 'multi',
+					selector: 'td:first-child',
+				},
+				columns: cols,
+				order: [1, 'desc'],
+				columnDefs: [
+					{
+						orderable: true,
+						className: 'select-checkbox',
+						targets: -1,
+						orderDataType: 'select-checkbox'
+					}
+				]
+			});
+		});
+
+		it('Checkbox is unchecked before selection', function() {
+			expect($('tbody tr:eq(7) td:eq(0) input').prop('checked')).toBe(false);
+		});
+
+		it('Checkbox is checked when cell is selected', function() {
+			$('tbody tr:eq(1) td:eq(0)').click();
+			expect($('tbody tr:eq(1) td:eq(0)').hasClass('selected')).toBe(true);
+			expect($('tbody tr:eq(1) td:eq(0) input').prop('checked')).toBe(true);
+		});
+
+		it('Other rows remain unchecked', function() {
+			expect($('tbody tr:eq(0) td:eq(0) input').prop('checked')).toBe(false);
+			expect($('tbody tr:eq(1) td:eq(0) input').prop('checked')).toBe(false);
+		});
+
+		it('Checkbox is unchecked when cell is deselected', function() {
+			$('tbody tr:eq(7) td:eq(0)').click();
+			expect($('tbody tr:eq(7) td:eq(0)').hasClass('selected')).toBe(false);
+			expect($('tbody tr:eq(7) td:eq(0) input').prop('checked')).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
When checkbox is renderered and items is `cell` then this construct:
```
// And make sure this checkbox matches it's row as it is possible
// to check out of sync if this was clicked on to deselect a range
// but remains selected itself
this.checked = $(this).closest('tr').hasClass('selected');
```
will when the checkbox is clicked uncheck the checkbox because the element that gets selected (that has the `selected` class) is the `td` element, not the `tr` element which is the case when items is `row`.

I have included a testfile with two tests, but I could not quite understand how to these tests are run, so they might fail, but the intent is correct. If they don't work you are free to fix them or delete them.

I acknowledge that my contribution is offered under and will be made available under the project's existing license (MIT).
 